### PR TITLE
Speed and minor tokenization issues fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Jesse Heaslip",
   "license": "MIT",
   "dependencies": {
-    "sentence-tokenizer": "0.0.8",
     "syllable": "^2.2.0"
   },
   "devDependencies": {

--- a/reading-level.js
+++ b/reading-level.js
@@ -17,8 +17,8 @@ exports.readingLevel = (text, full) => {
 
   const tokenSentences = text
     .replace('\0', '')
-	.replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
-	.replace(/(((^|\w).*?[^\w\s,]+)(?=\s+[A-Z])|:|;)/g, '$1\0')
+    .replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
+    .replace(/(((^|\w).*?[^\w\s,]+)(?=\s+\W*[A-Z])|:|;)/g, '$1\0')
     .split(/\s*\0\s*/)
 
   const tracker = {

--- a/reading-level.js
+++ b/reading-level.js
@@ -1,5 +1,4 @@
 const syllable = require('syllable')
-const Tokenizer = require('sentence-tokenizer')
 
 exports.readingLevel = (text, full) => {
   const err = 'Either no sentences or words, please enter valid text'
@@ -16,11 +15,12 @@ exports.readingLevel = (text, full) => {
     return err
   }
 
-  const tokenizer = new Tokenizer('ChuckNorris')
-  tokenizer.setEntry(text)
-  
-  const tokenSentences = tokenizer.getSentences()
-             
+  const tokenSentences = text
+    .replace('\0', '')
+	.replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
+	.replace(/(((^|\w).*?[^\w\s,]+)(?=\s+[A-Z])|:|;)/g, '$1\0')
+    .split(/\s*\0\s*/)
+
   const tracker = {
     syllables: 0,
     words: 0

--- a/reading-level.js
+++ b/reading-level.js
@@ -2,6 +2,19 @@ const syllable = require('syllable')
 const Tokenizer = require('sentence-tokenizer')
 
 exports.readingLevel = (text, full) => {
+  const err = 'Either no sentences or words, please enter valid text'
+
+  const result = {
+    sentences: 0, words: 0, syllables: 0, unrounded: NaN, rounded: NaN
+  }
+
+  if (!/[a-z]/i.test(text)) {
+    if (full == 'full') {
+      result.error = err
+      return result
+    }
+    return err
+  }
 
   const tokenizer = new Tokenizer('ChuckNorris')
   tokenizer.setEntry(text)
@@ -19,7 +32,6 @@ exports.readingLevel = (text, full) => {
     const words = sentence
                     .replace(/[^\w\s]|_/g, "")
                     .replace(/\s+/g, " ")
-                    .replace(/[0-9]/g, '')
                     .split(' ')
                     .filter(letter => letter)
 
@@ -35,11 +47,10 @@ exports.readingLevel = (text, full) => {
   const unrounded = 0.39 * (words / sentences) + 11.8 * (syllables / words) - 15.59
   const rounded = Math.round(isNaN(unrounded) ? NaN : unrounded)
 
-  const result = {
+  Object.assign(result, {
     sentences, words, syllables, unrounded, rounded
-  }
+  })
 
-  const err = 'Either no sentences or words, please enter valid text'
   const nan = isNaN(result.rounded)
 
   if (nan) {

--- a/reading-level.js
+++ b/reading-level.js
@@ -7,6 +7,13 @@ exports.readingLevel = (text, full) => {
     sentences: 0, words: 0, syllables: 0, unrounded: NaN, rounded: NaN
   }
 
+  const tokenSentences = text
+    .replace('\0', '')
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // strip diacritics since JS's \w group and explicit [a-z]|[A-Z] don't account for them
+    .replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
+    .replace(/(((^|\w).*?[^\w\s,]+)(?=\s+\W*[A-Z])|:|;)/g, '$1\0')
+    .split(/\s*\0\s*/)
+
   if (!/[a-z]/i.test(text)) {
     if (full == 'full') {
       result.error = err
@@ -14,12 +21,6 @@ exports.readingLevel = (text, full) => {
     }
     return err
   }
-
-  const tokenSentences = text
-    .replace('\0', '')
-    .replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
-    .replace(/(((^|\w).*?[^\w\s,]+)(?=\s+\W*[A-Z])|:|;)/g, '$1\0')
-    .split(/\s*\0\s*/)
 
   const tracker = {
     syllables: 0,

--- a/reading-level.js
+++ b/reading-level.js
@@ -10,7 +10,7 @@ exports.readingLevel = (text, full) => {
   const tokenSentences = text
     .replace('\0', '')
     .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // strip diacritics since JS's \w group and explicit [a-z]|[A-Z] don't account for them
-    .replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg)\./gi, '$1')
+    .replace(/(mr|mrs|dr|ms|prof|rev|col|cmdr|flt|lt|brgdr|hon|wng|capt|rt|revd|gen|cdre|admrl|herr|hr|frau|alderman|alhaji|brig|cdr|cik|consul|datin|dato|datuk|seri|dhr|dipl|ing|dott|sa|dra|drs|en|encik|eng|eur|exma|sra|exmo|sr|lieut|fr|fraulein|fru|graaf|gravin|grp|hajah|haji|hajim|hra|ir|lcda|lic|maj|mlle|mme|mstr|nti|sri|rva|sig|na|ra|sqn|ldr|srta|wg|co|esq|inc|iou|ltd|mdlle|messers|messrs|mlles|mm|mmes|mt|p\.s|pvt|st|viz)\./gi, '$1')
     .replace(/(((^|\w).*?[^\w\s,]+)(?=\s+\W*[A-Z])|:|;)/g, '$1\0')
     .split(/\s*\0\s*/)
 


### PR DESCRIPTION
Running on big bodies the previously used package took an unreasonable amount of time: 580s down to 8s after the changes for my main test source.

https://github.com/parmentf/node-sentence-tokenizer was also not designed for the task, other than being of dubious quality all around. After a quick search I didn't find any standards and https://www.tdi.texas.gov/pubs/pc/pccpfaq.html ( https://web.archive.org/web/20180314033843/https://www.tdi.texas.gov/pubs/pc/pccpfaq.html ) seemed good enough for a reference.

Issue found while testing https://github.com/daniel-j/fimfic2epub/commit/69dbb43dd3ccfbff6135dd7116c46cba986a93c0
Mocha tests complete, manual testing was done on random snippets and a complete txt of https://www.fimfiction.net/story/19198/background-pony

The regex first makes sure that there are characters (or the beginning of the string) to avoid useless symbols-filled groups, then matches every colon, semicolon, and any symbol followed by space and an uppercase character (excluding abbreviations like Dr. which were already escaped).
Line feeds without preceding punctuation aren't considered a splitting point: this helps for hard wrapped text possibly at the expense of poetry, but I think it makes sense for the latter to increase complexity and it's unlikely that there'd be enough to make a significant impact on the score anyway.
The match is then replaced with itself, as to only append the following null character that will serve as marker.